### PR TITLE
Stop detection at vcs directory

### DIFF
--- a/project-rootfile-tests.el
+++ b/project-rootfile-tests.el
@@ -88,6 +88,16 @@
         (should (string= (project-rootfile-root project) (file-name-as-directory sub-project2-dir)))
         (should (equal (project-rootfile-base project) (project-try-vc dir)))))))
 
+(ert-deftest test-project-rootfile-try-detect/stop-detection-at-vcs-directory ()
+  (project-rootfile-tests-with-setup (dir)
+    (make-empty-file (expand-file-name "Makefile" dir))
+    (make-directory (expand-file-name "vcs/child" dir) t)
+    (let ((default-directory (expand-file-name "vcs" dir)))
+      (call-process-shell-command "git init"))
+    (should (project-rootfile-try-detect dir))
+    (should-not (project-rootfile-try-detect (expand-file-name "vcs" dir)))
+    (should-not (project-rootfile-try-detect (expand-file-name "vcs/child" dir)))))
+
 (ert-deftest test-project-rootfile/project-current ()
   (project-rootfile-tests-with-setup (dir)
     (make-empty-file (expand-file-name "Makefile" dir))

--- a/project-rootfile-tests.el
+++ b/project-rootfile-tests.el
@@ -50,7 +50,7 @@
     (make-empty-file (expand-file-name "Makefile" dir))
     (let ((project (project-rootfile-try-detect dir)))
       (should (cl-typep project 'project-rootfile))
-      (should (string= (project-root project) (file-name-as-directory dir)))
+      (should (string= (project-rootfile-root project) (file-name-as-directory dir)))
       (should (string= (project-rootfile-root project) (file-name-as-directory dir)))
       (should (null (project-rootfile-base project))))))
 
@@ -59,13 +59,13 @@
     (make-empty-file (expand-file-name "Makefile" dir))
     (make-directory (expand-file-name "child" dir))
     (let ((project (project-rootfile-try-detect (expand-file-name "child" dir))))
-      (should (string= (project-root project) (file-name-as-directory dir))))))
+      (should (string= (project-rootfile-root project) (file-name-as-directory dir))))))
 
 (ert-deftest test-project-rootfile-try-detect/nested-root-file ()
   (project-rootfile-tests-with-setup (dir)
     (make-empty-file (expand-file-name "debian/control" dir) t)
     (let ((project (project-rootfile-try-detect dir)))
-      (should (string= (project-root project) (file-name-as-directory dir))))))
+      (should (string= (project-rootfile-root project) (file-name-as-directory dir))))))
 
 (ert-deftest test-project-rootfile-try-detect/inside-git ()
   (project-rootfile-tests-with-setup (dir :inside-git t)

--- a/project-rootfile.el
+++ b/project-rootfile.el
@@ -99,13 +99,18 @@
 (defun project-rootfile-try-detect (dir)
   "Entry point of `project-find-functions' for `project-rootfile'.
 Return an instance of `project-rootfile' if DIR is it's target."
-  (when-let (root (locate-dominating-file dir #'project-rootfile--root-p))
-    (make-project-rootfile :root root :base (project-try-vc dir))))
+  (let* ((base (project-try-vc dir))
+         (stop-dir (and base (car (project-roots base)))))
+    (when-let (root (locate-dominating-file dir (lambda (d) (project-rootfile--root-p d stop-dir))))
+      (make-project-rootfile :root root :base base))))
 
-(defun project-rootfile--root-p (dir)
-  "Return non-nil if DIR is a project root."
-  (seq-some (lambda (f) (file-exists-p (expand-file-name f dir)))
-            project-rootfile-list))
+(defun project-rootfile--root-p (dir &optional stop-dir)
+  "Return non-nil if DIR is a project root.
+If STOP-DIR is specified, return nil if DIR is not a subdirectory of it."
+  (and (or (null stop-dir)
+           (file-in-directory-p dir stop-dir))
+       (seq-some (lambda (f) (file-exists-p (expand-file-name f dir)))
+                 project-rootfile-list)))
 
 (cl-defmethod project-root ((project project-rootfile))
   "Return root directory of the current PROJECT."

--- a/project-rootfile.el
+++ b/project-rootfile.el
@@ -100,7 +100,7 @@
   "Entry point of `project-find-functions' for `project-rootfile'.
 Return an instance of `project-rootfile' if DIR is it's target."
   (let* ((base (project-try-vc dir))
-         (stop-dir (and base (car (project-roots base)))))
+         (stop-dir (and base (car (with-no-warnings (project-roots base))))))
     (when-let (root (locate-dominating-file dir (lambda (d) (project-rootfile--root-p d stop-dir))))
       (make-project-rootfile :root root :base base))))
 
@@ -112,11 +112,12 @@ If STOP-DIR is specified, return nil if DIR is not a subdirectory of it."
        (seq-some (lambda (f) (file-exists-p (expand-file-name f dir)))
                  project-rootfile-list)))
 
-(cl-defmethod project-root ((project project-rootfile))
-  "Return root directory of the current PROJECT."
-  (project-rootfile-root project))
+(when (cl-generic-p 'project-root)
+  (cl-defmethod project-root ((project project-rootfile))
+    "Return root directory of the current PROJECT."
+    (project-rootfile-root project)))
 
-(when (< emacs-major-version 28)
+(with-no-warnings
   (cl-defmethod project-roots ((project project-rootfile))
     "Return the list containing the current PROJECT root."
     (list (project-rootfile-root project))))


### PR DESCRIPTION
Incorrect project instance was created when a root file exists at parents of vcs directory.

For example, in the following directory layout:

```
~/tmp/xxx
├── Makefile
└── vcs
    └── .git
```

`(project-rootfile-try-detect "~/tmp/xxx/vcs")` returns as the following:

```lisp
(project-rootfile "~/tmp/xxx/" (vc . "~/tmp/tmp/vcs"))
```
