### PR TITLE
Load macros for compilation

### DIFF
--- a/project-rootfile.el
+++ b/project-rootfile.el
@@ -49,7 +49,7 @@
 ;;; Code:
 
 (require 'project)
-(eval-when-compile (require 'cl-macs))
+(require 'cl-lib)
 
 (defgroup project-rootfile nil
   "Extension of `project' to detect project root with root file (e.g. Gemfile)."

--- a/project-rootfile.el
+++ b/project-rootfile.el
@@ -49,6 +49,7 @@
 ;;; Code:
 
 (require 'project)
+(eval-when-compile (require 'cl-macs))
 
 (defgroup project-rootfile nil
   "Extension of `project' to detect project root with root file (e.g. Gemfile)."


### PR DESCRIPTION
I think you need cl-macs at compile time to get macros such as cl-defstruct to work