### PR TITLE
fix test and ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         emacs_version:
-          - 27.2
-          - 28.1
+          - 29.4
+          - 30.2
           - snapshot
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,18 @@
 TARGETS = project-rootfile.elc
+EMACS = emacs
 
 default: compile test
 
 %.elc: %.el
-	emacs -Q -batch -L . --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile $<
+	$(EMACS) -Q -batch -L . --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile $<
 
 .PHONY: clean
 clean:
-	rm *.elc
+	rm -f *.elc
 
 .PHONY: compile
 compile: $(TARGETS)
 
 .PHONY: test
 test:
-	emacs -Q -batch -L . -l ert -l project-rootfile-tests -f ert-run-tests-batch-and-exit
+	$(EMACS) -Q -batch -L . -l ert -l project-rootfile-tests -f ert-run-tests-batch-and-exit

--- a/project-rootfile-tests.el
+++ b/project-rootfile-tests.el
@@ -105,6 +105,9 @@
       (should (member "ignore" (project-ignores project dir))))))
 
 (ert-deftest test-project-rootfile/project-ignores/inside-git ()
+  ;; skip when emacs29. see https://github.com/emacs-mirror/emacs/commit/c640e978874385f9774c2903b97677406bee97a2
+  (skip-unless (not (emacs-major-version emacs-major-version 29)))
+
   (project-rootfile-tests-with-setup (dir :inside-git t :touch "Makefile")
     (let ((project (project-rootfile-try-detect dir)))
       (should (not (member "ignore" (project-ignores project dir))))

--- a/project-rootfile-tests.el
+++ b/project-rootfile-tests.el
@@ -19,11 +19,12 @@
 
 ;;; Commentary:
 
-;; 
+;;
 
 ;;; Code:
 
 (require 'ert)
+(require 'vc)                           ; to register vc callbacks
 (require 'project-rootfile)
 
 
@@ -46,7 +47,7 @@
 
 (defun project-rootfile-tests-root-equal (project dir)
   "Return non-nil if root of PROJECT is DIR."
-  (string= (project-rootfile--project-root project) (file-name-as-directory dir)))
+  (file-equal-p (project-rootfile--project-root project) (file-name-as-directory dir)))
 
 (ert-deftest test-project-rootfile-try-detect ()
   (project-rootfile-tests-with-setup (dir)

--- a/project-rootfile.el
+++ b/project-rootfile.el
@@ -103,7 +103,7 @@
 Search a root file upwards from DIR and return project instance if found."
   (let* ((vc-project (project-try-vc dir))
          (stop-dir (and vc-project (project-rootfile--project-root vc-project))))
-    (when-let (root (locate-dominating-file dir (lambda (d) (project-rootfile--root-p d stop-dir))))
+    (when-let* ((root (locate-dominating-file dir (lambda (d) (project-rootfile--root-p d stop-dir)))))
       (pcase vc-project
         ((pred null) (make-project-rootfile-plain :root root))
         (`(vc ,backend ,_vc-root) (list 'vc backend root))


### PR DESCRIPTION
* use when-let* instead of when-let to suppress byte compilation errors.
* update version  matrix
* fix test to pass on emacs-29, 30 and snapshot